### PR TITLE
Update GerenciadorMemoriaPaginacao.java

### DIFF
--- a/Gerenciamento dinamico de Memoria/GerenciadorMemoriaPaginacao.java
+++ b/Gerenciamento dinamico de Memoria/GerenciadorMemoriaPaginacao.java
@@ -96,7 +96,7 @@ public class GerenciadorMemoriaPaginacao {
         return livres;
     }
 
-    private void liberarEspaco(int paginasNecessarias) {
+    private void liberarEspaco() {
         int paginasParaLiberar = (int) Math.ceil(0.3 * paginasOcupadas.length);
         int paginasLiberadas = 0;
 


### PR DESCRIPTION
Retirada do parâmetro páginas necessárias do método liberarEspaço, estava sendo inutilizado devido ao numero de páginas a ser removido ser sempre 30% do total.